### PR TITLE
fixed build on Windows/mingw (no UnixSocket)

### DIFF
--- a/Database/PostgreSQL/Typed/TH.hs
+++ b/Database/PostgreSQL/Typed/TH.hs
@@ -34,7 +34,11 @@ import Data.Maybe (isJust, fromMaybe)
 import Data.String (fromString)
 import qualified Data.Traversable as Tv
 import qualified Language.Haskell.TH as TH
+#ifdef mingw32_HOST_OS
+import Network (PortID(PortNumber), PortNumber)
+#else
 import Network (PortID(UnixSocket, PortNumber), PortNumber)
+#endif
 import System.Environment (lookupEnv)
 import System.IO.Unsafe (unsafePerformIO, unsafeInterleaveIO)
 
@@ -50,7 +54,11 @@ getTPGDatabase = do
   db   <- fromMaybe user <$> lookupEnv "TPG_DB"
   host <- fromMaybe "localhost" <$> lookupEnv "TPG_HOST"
   pnum <- maybe (5432 :: PortNumber) ((fromIntegral :: Int -> PortNumber) . read) <$> lookupEnv "TPG_PORT"
+#ifdef mingw32_HOST_OS
+  let port = PortNumber pnum
+#else
   port <- maybe (PortNumber pnum) UnixSocket <$> lookupEnv "TPG_SOCK"
+#endif
   pass <- fromMaybe "" <$> lookupEnv "TPG_PASS"
   debug <- isJust <$> lookupEnv "TPG_DEBUG"
   return $ defaultPGDatabase

--- a/test/Connect.hs
+++ b/test/Connect.hs
@@ -6,8 +6,7 @@ import Network (PortID(UnixSocket))
 
 db :: PGDatabase
 db = defaultPGDatabase
-  { pgDBPort = UnixSocket "/tmp/.s.PGSQL.5432"
-  , pgDBName = "templatepg"
+  { pgDBName = "templatepg"
   , pgDBUser = "templatepg"
   , pgDBDebug = True
   , pgDBParams = [("TimeZone", "UTC")]


### PR DESCRIPTION
Build on windows/mingw fails because of UnixSocket import and usage.
Fixed using ifdefs on mingw32_HOST_OS .