### PR TITLE
Change getQueryString to take PGTypeEnv instead of PGConnection

### DIFF
--- a/Database/PostgreSQL/Typed/Query.hs
+++ b/Database/PostgreSQL/Typed/Query.hs
@@ -52,7 +52,7 @@ class PGQuery q a | q -> a where
   --
   -- > [pgSQL|SELECT a FROM t|] `unsafeModifyQuery` (<> (" WHERE a = " <> pgSafeLiteral x))
   unsafeModifyQuery :: q -> (BS.ByteString -> BS.ByteString) -> q
-  getQueryString :: PGConnection -> q -> BS.ByteString
+  getQueryString :: PGTypeEnv -> q -> BS.ByteString
 class PGQuery q PGValues => PGRawQuery q
 
 -- |Execute a query that does not return results.
@@ -90,7 +90,7 @@ data QueryParser q a = QueryParser (PGTypeEnv -> q) (PGTypeEnv -> PGValues -> a)
 instance PGRawQuery q => PGQuery (QueryParser q a) a where
   pgRunQuery c (QueryParser q p) = second (fmap $ p e) <$> pgRunQuery c (q e) where e = pgTypeEnv c
   unsafeModifyQuery (QueryParser q p) f = QueryParser (\e -> unsafeModifyQuery (q e) f) p
-  getQueryString c (QueryParser q _) = getQueryString c $ q $ pgTypeEnv c
+  getQueryString e (QueryParser q _) = getQueryString e $ q e
 
 instance Functor (QueryParser q) where
   fmap f (QueryParser q p) = QueryParser q (\e -> f . p e)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -137,7 +137,7 @@ main = do
     $ selectProp c
     Q..&&. tokenProp
     Q..&&. [pgSQL|#abc ${3.14::Float} def $f$ $$ ${1} $f$${2::Int32}|] Q.=== "abc 3.14::real def $f$ $$ ${1} $f$2::integer"
-    Q..&&. getQueryString c ([pgSQL|SELECT ${"ab'cd"::String}::text, ${3.14::Float}::float4|] :: PGSimpleQuery (Maybe String, Maybe Float)) Q.=== "SELECT 'ab''cd'::text, 3.14::float4"
+    Q..&&. getQueryString (pgTypeEnv c) ([pgSQL|SELECT ${"ab'cd"::String}::text, ${3.14::Float}::float4|] :: PGSimpleQuery (Maybe String, Maybe Float)) Q.=== "SELECT 'ab''cd'::text, 3.14::float4"
     Q..&&. pgEnumValues Q.=== [(MyEnum_abc, "abc"), (MyEnum_DEF, "DEF"), (MyEnum_XX_ye, "XX_ye")]
     Q..&&. Q.conjoin (map (\(s, t) -> sqlTokens s Q.=== t)
       [ ("",


### PR DESCRIPTION
We have a need for using `getQueryString`, but we don't have access to a `PGConnection`.
I don't have full context on how the internals of postgresql-typed works, but I think it's actually not necessary for the function. This would be awesome for our usecase, though.
Does this change make sense to you?
Is there something you'd like me to adjust?