### PR TITLE
Fix auth issue with Crypton

### DIFF
--- a/Database/PostgreSQL/Typed/Protocol.hs
+++ b/Database/PostgreSQL/Typed/Protocol.hs
@@ -73,7 +73,7 @@ import           Control.Exception (Exception, onException, finally, throwIO)
 import           Control.Exception (catch)
 #endif
 import           Control.Monad (void, liftM2, replicateM, when, unless)
-#ifdef VERSION_cryptonite
+#if defined(VERSION_cryptonite) || defined(VERSION_crypton)
 import qualified Crypto.Hash as Hash
 import qualified Data.ByteArray.Encoding as BA
 #endif
@@ -413,7 +413,7 @@ pgConnectionDatabase = connDatabase
 pgTypeEnv :: PGConnection -> PGTypeEnv
 pgTypeEnv = connTypeEnv
 
-#ifdef VERSION_cryptonite
+#if defined(VERSION_cryptonite) || defined(VERSION_crypton)
 md5 :: BS.ByteString -> BS.ByteString
 md5 = BA.convertToBase BA.Base16 . (Hash.hash :: BS.ByteString -> Hash.Digest Hash.MD5)
 #endif
@@ -728,7 +728,7 @@ pgConnect db = do
     pgSend c $ PasswordMessage $ pgDBPass db
     pgFlush c
     conn c
-#ifdef VERSION_cryptonite
+#if defined(VERSION_cryptonite) || defined(VERSION_crypton)
   msg c (Left (AuthenticationMD5Password salt)) = do
     pgSend c $ PasswordMessage $ "md5" `BS.append` md5 (md5 (pgDBPass db <> pgDBUser db) `BS.append` salt)
     pgFlush c

--- a/postgresql-typed.cabal
+++ b/postgresql-typed.cabal
@@ -112,7 +112,7 @@ Library
     if flag(scientific)
       Build-Depends: scientific >= 0.3
   if flag(aeson)
-    Build-Depends: aeson >= 0.7
+    Build-Depends: aeson >= 0.7 && < 2.2
   if flag(HDBC)
     Build-Depends: HDBC >= 2.2
     Exposed-Modules:


### PR DESCRIPTION
I'm getting the following error when attempting to use this repo with the crypton flag enabled against a password protected PG instance:
```
    • Exception when trying to run compile-time code:
        user error (pgConnect: unexpected response: AuthenticationMD5Password "\139\156\132v"
```

This fixes CPP checks to use the same code paths for cryptonite and crypton.

Also adding an upper bound to aeson because of a [recent breaking change](https://hackage.haskell.org/package/aeson-2.2.0.0/changelog). 
I'll send another PR for the aeson migration, but it'd be great if you could do two separate releases, as the aeson upgrade will force 2.2 and it's breaking some of our builds.
... And I imagine it will be the case for other projects out there.